### PR TITLE
Fix Bundle.module by adding resources declaration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,9 @@ let package = Package(
         .library(name: "AlertController", targets: ["AlertController"]),
     ],
     targets: [
-        .target(name: "AlertController"),
+        .target(
+            name: "AlertController",
+            resources: [.process("Resources")]
+        ),
     ]
 )


### PR DESCRIPTION
## Summary
- Added `resources: [.process("Resources")]` to the AlertController target in Package.swift
- This fixes the build error where `Bundle.module` is undefined because SPM wasn't aware of the Resources directory
- The `AlertControllerConfiguration.swift` uses `Bundle.module` for localization support, which requires this declaration

## Test plan
- [x] Verified build succeeds with `xcodebuild -scheme AlertController -destination 'platform=iOS Simulator,...'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)